### PR TITLE
add command line option for display of hand overlay

### DIFF
--- a/VideoGenerator.py
+++ b/VideoGenerator.py
@@ -76,7 +76,7 @@ def get_frames_to_render(file_type: str, path_to_file: str):
     raise NotImplemented
 
 
-def capture_live(frames):
+def capture_live(frames, show=False):
     cap = cv2.VideoCapture(0)  # windows warning solution  cv2.CAP_DSHOW
     cap.set(3, 1280)
     cap.set(4, 720)
@@ -90,8 +90,10 @@ def capture_live(frames):
     while cap.isOpened():
         success, video_img = cap.read()
         video_img = cv2.flip(video_img, 1)
-        # hands = detector.findHands(video_img, draw=False)  # don't draw
-        hands, video_img = detector.findHands(video_img)  # draw
+        if show:
+            hands, video_img = detector.findHands(video_img)
+        else:
+            hands = detector.findHands(video_img, draw = False)
         if len(hands) == 2:
             img = next(frames)
             left_hand = hands[0]
@@ -118,9 +120,9 @@ def capture_live(frames):
             break
 
 
-def live_video_generator(file_type, path_to_file=None):
+def live_video_generator(file_type, path_to_file=None, show=False):
     frames = get_frames_to_render(file_type, path_to_file)
-    capture_live(cycle(frames))
+    capture_live(cycle(frames), show)
 
 
 if __name__ == "__main__":

--- a/start.py
+++ b/start.py
@@ -7,16 +7,19 @@ from VideoGenerator import live_video_generator
               default="png", type=str,
               help="extension of file to be rendered as rasengan. should be in [png,gif,mp4]", )
 @click.option("--file", "-f", type=str,
-              help="location of file to be renders as rasengan", )
-def cli(ext: str, file: str) -> None:
+              help="location of file to be rendered as rasengan", )
+@click.option("--show", "-s", is_flag=True, default=False,
+              help="show hand overlay", )
+def cli(ext: str, file: str, show: bool) -> None:
     ext = ext.lower()
     if not ext in ['png', 'gif', 'mp4']:
         click.echo(f"not proper type of file")
         return
+    if show:
+        click.echo("Show hand overlay enabled")
     click.echo(f"importing <{ext}> from <{file}>")
-    live_video_generator(ext, file)
+    live_video_generator(ext, file, show)
     click.echo("Done!")
-
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
By default, hand overlay is turned off. It is configured to be enabled by using the option flag '-s' or '--show'.
This PR fixes #8.